### PR TITLE
FEAT: issue#86 - duration set to 0 turn off the timer, notification has to be dismissed manually.  

### DIFF
--- a/src/core/hooks/useTimer.ts
+++ b/src/core/hooks/useTimer.ts
@@ -11,6 +11,7 @@ export const useTimer = () => {
 
   const resetTimer = useCallback(
     (callback: () => void, duration: number) => {
+      if (!duration) return
       clearTimer()
       timerId.current = setTimeout(callback, duration)
     },


### PR DESCRIPTION
-Add short logical checking for the 'duration' parameter: if equals to 0 (logical false)

the function 'resetTimer' returns and doesn't invoke setTimeout, otherwise setTimeout takes the time length passed as duration

Closes #86 
