### PR TITLE
chore: disable project auto-assign gh workflow (temporarily)

### DIFF
--- a/.github/workflows/auto_assign_issue.yml
+++ b/.github/workflows/auto_assign_issue.yml
@@ -1,22 +1,22 @@
 name: Auto Assign to Project(s)
 
-on:
-  issues:
-    types: [opened, labeled]
-  pull_request:
-    types: [opened, labeled]
-  issue_comment:
-    types: [created]
+# on:
+#   issues:
+#     types: [opened, labeled]
+#   pull_request:
+#     types: [opened, labeled]
+#   issue_comment:
+#     types: [created]
 
 jobs:
   assign_one_project:
     runs-on: ubuntu-latest
     name: Assign to One Project
     steps:
-    - name: Assign NEW issues and NEW pull requests to project 2
-      uses: srggrs/assign-one-project-github-action@1.2.1
-      if: github.event.action == 'opened'
-      with:
-        project: 'https://github.com/orgs/TheWidlarzGroup/projects/2'
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Assign NEW issues and NEW pull requests to project
+        uses: srggrs/assign-one-project-github-action@1.2.1
+        if: github.event.action == 'opened'
+        with:
+          project: 'https://github.com/orgs/TheWidlarzGroup/projects/2'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Why?**

GH project is not in use right now, no need to keep the job active