### PR TITLE
chore: remove duplicated prettier config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,1 +1,0 @@
-"@twgdev/prettier-config"


### PR DESCRIPTION
**Why?**

Pretteir config is already specified in package.json
